### PR TITLE
fix: prevent marksman from indexing home

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -309,7 +309,15 @@ require('lazy').setup({
         jdtls = {},
         bashls = {},
         marksman = {
-          cmd = { 'marksman', 'server', '--config', vim.fn.expand('~/.config/nvim/marksman/global.toml') }
+          cmd = { 'marksman', 'server', '--config', vim.fn.expand('~/.config/nvim/marksman/global.toml') },
+          root_dir = function(fname)
+            local util = require('lspconfig.util')
+            local root = util.root_pattern('.marksman.toml', '.git')(fname)
+            if root == vim.loop.os_homedir() then
+              return nil
+            end
+            return root
+          end,
         },
       }
 

--- a/setup.rb
+++ b/setup.rb
@@ -54,6 +54,7 @@ end
 dotfiles.glob('{.config/*,.*}').each do |file|
   next if file == dotfiles || file == dotfiles.parent
   next if file.to_s =~ %r{/\.(?:config|git|gitignore)$}
+  next if file.basename.to_s == '.marksman.toml'
 
   link_path(file, TARGET/file.relative_path_from(dotfiles))
 end


### PR DESCRIPTION
## Summary
- prevent marksman from using $HOME as a workspace root
- stop setup from linking repo-local `.marksman.toml` into $HOME
