### PR TITLE
chore: update codex and kotlin editor shortcuts

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -71,6 +71,7 @@ abbr -a ll ls -lhavGF
 abbr -a e code
 abbr -a i idea
 abbr -a cc codex
+abbr -a ccr codex resume
 abbr -a gs git status -sb
 abbr -a gco git checkout
 abbr -a gfa git fetch --all

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -714,7 +714,7 @@ require('lazy').setup({
       notify_on_error = true,
       format_on_save = function(bufnr)
         -- Disable for specific filetypes if needed
-        local disable_filetypes = { c = true, cpp = true }
+        local disable_filetypes = { c = true, cpp = true, kotlin = true }
         if disable_filetypes[vim.bo[bufnr].filetype] then
           return nil
         else


### PR DESCRIPTION
## Summary
- Add the `ccr` abbreviation for `codex resume` in Fish
- Disable format on save for Kotlin files in Neovim