### PR TITLE
fix: restore delta gitconfig include

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -86,3 +86,5 @@
   tool = code
 [mergetool "code"]
   cmd = code --wait --merge $REMOTE $LOCAL $BASE $MERGED
+[include]
+  path = ~/.config/git/delta.gitconfig


### PR DESCRIPTION
## Summary
- Restore the delta gitconfig include removed when switching Git pager to hunk
- Keep the current Git core pager setting unchanged
