### PR TITLE
feat: switch to claude aliases, add git-wt init, update tools and themes

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -46,6 +46,10 @@ if test -d $HOMEBREW_HOME/bin
     end
 end
 
+if type -q git-wt
+    git-wt --init fish | source
+end
+
 if type -q mise
     mise activate fish | source
 end
@@ -91,8 +95,9 @@ abbr -a .... cd ../../../
 abbr -a ll ls -lhavGF
 abbr -a e code
 abbr -a i idea
-abbr -a cc codex
-abbr -a ccr codex resume
+abbr -a c claude
+abbr -a cc claude --continue
+abbr -a cr claude --resume
 abbr -a gs git status -sb
 abbr -a gco git checkout
 abbr -a gfa git fetch --all

--- a/.config/git/delta.gitconfig
+++ b/.config/git/delta.gitconfig
@@ -98,10 +98,10 @@
   line-numbers-plus-style = "#66800b"
   line-numbers-right-style = "#878580"
   line-numbers-zero-style = "#9f9d96"
-  minus-emph-style = bold "#100f0f" "#ffcabb"
-  minus-style = "#100f0f" "#ffe1d5"
-  plus-emph-style = bold "#100f0f" "#cdd597"
-  plus-style = "#100f0f" "#edeecf"
+  minus-emph-style = bold "#100f0f" "#F89A8A"
+  minus-style = syntax "#FFCABB"
+  plus-emph-style = bold "#100f0f" "#BEC97E"
+  plus-style = syntax "#DDE2B2"
   side-by-side = false
   syntax-theme = flexoki-light
 

--- a/.config/hunk/state.json
+++ b/.config/hunk/state.json
@@ -1,4 +1,4 @@
 {
   "version": 1,
-  "lastSeenCliVersion": "0.14.0"
+  "lastSeenCliVersion": "0.14.1"
 }

--- a/.config/lazygit/theme-light.yml
+++ b/.config/lazygit/theme-light.yml
@@ -9,7 +9,9 @@ gui:
     inactiveBorderColor:
       - "#b7b5ac"
     selectedLineBgColor:
-      - "#e6e4d9"
+      - "#cfe2f7"
+    inactiveViewSelectedLineBgColor:
+      - "#e2eef9"
     selectedRangeBgColor:
       - "#dad8ce"
     cherryPickedCommitBgColor:

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -43,6 +43,7 @@ lazygit = "0.61.1"
 pre-commit = "4.6.0"
 starship = "1.25.1"
 yazi = "26.5.6"
+"npm:ccusage" = "20.0.6"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node"]


### PR DESCRIPTION
## 変更内容

### fish 設定
- `git-wt --init fish` の初期化を追加（mise で git-wt が使える環境向け）
- `codex` 向けの abbr を `claude` コマンド向けに更新
  - `cc codex` → `c claude`
  - `cc codex` → `cc claude --continue`
  - `ccr codex resume` → `cr claude --resume`

### テーマ・外観
- `delta.gitconfig`: flexoki-light テーマの diff カラーを調整（minus/plus の強調色を更新）
- `lazygit/theme-light.yml`: 選択行の背景色をブルー系に変更し、非アクティブビューの選択行色を追加

### ツール
- `mise/config.toml`: `npm:ccusage 20.0.6` を追加
- `hunk/state.json`: `lastSeenCliVersion` を `0.14.1` に更新

## 手動確認手順

- `./setup.sh -t` でシンボリックリンクの確認
- `fish -n .config/fish/config.fish` で構文チェック
- 新しいシェルセッションで `c`、`cc`、`cr` エイリアスが動作することを確認
- delta の diff カラーが意図通り表示されることを確認