### PR TITLE
fix: correct git pager command from 'hunk pager' to 'hunk'

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -40,7 +40,7 @@
 [init]
   defaultBranch = main
 [core]
-  pager = hunk pager
+  pager = hunk
   hooksPath = ~/.config/git/hooks
   quotepath = false
   precomposeunicode = true


### PR DESCRIPTION
## 変更内容

`.config/git/config` の `core.pager` 設定を修正