### PR TITLE
fix: ignore all GnuPG runtime files except gpg-agent.conf

### DIFF
--- a/.gnupg/.gitignore
+++ b/.gnupg/.gitignore
@@ -1,8 +1,3 @@
 # GnuPG runtime and state (do not version)
-S.gpg-agent*
-S.scdaemon
-private-keys-v1.d/
-pubring.kbx
-pubring.kbx~
-trustdb.gpg
-tofu.db
+*
+!gpg-agent.conf


### PR DESCRIPTION
## Summary
- ignore all files in .gnupg by default
- keep gpg-agent.conf tracked explicitly
- avoid committing GnuPG runtime and state files