### PR TITLE
feat: enhance fzf_tmux_files_popup with multi-select and AI tool @ prefix

### DIFF
--- a/.config/fish/functions/fzf_tmux_files_popup.fish
+++ b/.config/fish/functions/fzf_tmux_files_popup.fish
@@ -1,20 +1,49 @@
 function fzf_tmux_files_popup
+    # PARENT_PANE / PARENT_PID are injected by the tmux.conf popup command
+    set -l parent_pane "$PARENT_PANE"
+    set -l parent_pid "$PARENT_PID"
+    if test -z "$parent_pane"
+        set parent_pane (tmux display-message -p '#{pane_id}')
+    end
+    if test -z "$parent_pid"
+        set parent_pid (tmux display-message -p '#{pane_pid}')
+    end
+
+    # Detect if parent pane is running an AI coding tool → prefix paths with '@'
+    set -l at_prefix_mode false
+    if pgrep -P "$parent_pid" -f 'claude|gemini|codex|copilot' > /dev/null 2>&1
+        set at_prefix_mode true
+    end
+
     set -l selected (
-        fd --hidden --follow --exclude .git --strip-cwd-prefix |
-        fzf --exit-0 --no-multi \
+        fd --hidden --follow --type f --type d --exclude .git --exclude .DS_Store --strip-cwd-prefix |
+        fzf --exit-0 --multi \
             --height=100% \
-            --prompt="files> " \
+            --prompt="Files> " \
             --preview '
-                if [ -d {} ]
+                if [ -d {} ]; then
                     eza --all --icons --color=always --tree --level=2 --git-ignore {}
                 else
                     bat --color=always --style=numbers --line-range :300 {}
-                end
+                fi
             ' \
             --preview-window=down:60%:wrap
     )
 
-    if test -n "$selected"
-        tmux send-keys -l -- "$selected"
+    if not set -q selected[1]
+        return 0
     end
+
+    set -l output ""
+    if test "$at_prefix_mode" = true
+        for path in $selected
+            set output "$output@$path "
+        end
+    else
+        for path in $selected
+            set output "$output"(string escape -- $path)" "
+        end
+    end
+
+    tmux send-keys -t "$parent_pane" -l -- "$output"
 end

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -37,7 +37,7 @@ bind -n C-S-. next-window
 bind -n C-S-w display-popup -E "fish -c 'fzf_tmux_windows_popup'"
 
 # files
-bind C-f display-popup -d "#{pane_current_path}" -E -w 80% -h 80% "fish -c 'fzf_tmux_files_popup'"
+bind C-f display-popup -d "#{pane_current_path}" -E -w 80% -h 80% "PARENT_PANE=#{pane_id} PARENT_PID=#{pane_pid} fish -c 'fzf_tmux_files_popup'"
 bind C-g display-popup -d "#{pane_current_path}" -w 95% -h 90% "lazygit"
 
 # Swap pane


### PR DESCRIPTION
## Overview

Enhance `fzf_tmux_files_popup` to correctly target the originating pane, support multi-file selection, and automatically prefix paths with `@` when an AI coding tool is detected in the parent pane.

### Changes

**`.config/fish/functions/fzf_tmux_files_popup.fish`**
- Accept `PARENT_PANE` / `PARENT_PID` env vars injected by tmux (with fallback to current pane/pid) so `send-keys` always targets the correct pane
- Detect AI coding tools (`claude`, `gemini`, `codex`, `copilot`) via `pgrep -P` on the parent PID and enable `@`-prefix mode when found
- Switch fzf from `--no-multi` to `--multi` to allow selecting multiple files at once
- Fix fzf preview shell syntax from fish `if/end` to POSIX `if/fi`
- Shell-escape paths when not in AI prefix mode

**`.config/tmux/tmux.conf`**
- Inject `PARENT_PANE=#{pane_id}` and `PARENT_PID=#{pane_pid}` into the popup command for `bind C-f`