### PR TITLE
fix: gd -> git diff, hd -> hunk diff

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -105,7 +105,8 @@ abbr -a gl git l
 abbr -a ga git add
 abbr -a gc git czg ai
 abbr -a gb git branch
-# abbr -a gd git diff -ubw
+abbr -a gd git diff -ubw
+abbr -a hd hunk diff --theme $HUNK_THEME --watch
 abbr -a gp git pull
 abbr -a gr git graph -l
 abbr -a lg lazygit

--- a/.config/fish/functions/__dotfiles_apply_theme_mode.fish
+++ b/.config/fish/functions/__dotfiles_apply_theme_mode.fish
@@ -71,11 +71,5 @@ function __dotfiles_apply_theme_mode --description 'Apply dotfiles theme variabl
     __dotfiles_set_theme_var $scope DELTA_FEATURES $delta_features
     __dotfiles_set_theme_var $scope HUNK_THEME $hunk_theme
     __dotfiles_set_theme_var $scope LG_CONFIG_FILE $lazygit_config
-    __dotfiles_set_theme_var $scope GIT_PAGER "hunk pager --theme $hunk_theme"
     __dotfiles_set_theme_var $scope FZF_DEFAULT_OPTS "--color=$mode" --cycle --layout=reverse --height=90% --preview-window=wrap '--marker=*'
-
-    if status is-interactive
-        abbr -q gd; and abbr -e gd
-        abbr -a gd 'hunk diff --theme $HUNK_THEME --watch'
-    end
 end

--- a/.config/fish/functions/theme_sync.fish
+++ b/.config/fish/functions/theme_sync.fish
@@ -36,7 +36,7 @@ function theme_sync --description 'Sync dotfiles theme with the current macOS ap
         return 0
     end
 
-    set -l theme_vars DOTFILES_THEME_MODE BAT_THEME BAT_THEME_LIGHT BAT_THEME_DARK NVIM_THEME TMUX_THEME DELTA_FEATURES HUNK_THEME LG_CONFIG_FILE GIT_PAGER FZF_DEFAULT_OPTS
+    set -l theme_vars DOTFILES_THEME_MODE BAT_THEME BAT_THEME_LIGHT BAT_THEME_DARK NVIM_THEME TMUX_THEME DELTA_FEATURES HUNK_THEME LG_CONFIG_FILE FZF_DEFAULT_OPTS
     for name in $theme_vars
         if set -q $name
             set -l value (string join -- ' ' $$name)

--- a/.config/git/config
+++ b/.config/git/config
@@ -41,6 +41,10 @@
   defaultBranch = main
 [core]
   pager = hunk
+[pager]
+  diff = delta
+  log = less -FRX
+  show = less -FRX
   hooksPath = ~/.config/git/hooks
   quotepath = false
   precomposeunicode = true


### PR DESCRIPTION
## What

- Re-enable `gd` abbreviation as `git diff -ubw` (static, in `config.fish`)
- Add `hd` abbreviation for `hunk diff --theme $HUNK_THEME --watch`
- Remove dynamic `gd` override and `GIT_PAGER` env var from `__dotfiles_apply_theme_mode`
- Drop `GIT_PAGER` from `theme_sync` tracked vars
- Configure git pager: `diff = delta`, `log` / `show` = `less -FRX`