### PR TITLE
fix: restore file relay and @ prefix detection in fzf_tmux_files_popup

### DIFF
--- a/.config/fish/functions/fzf_tmux_files_popup.fish
+++ b/.config/fish/functions/fzf_tmux_files_popup.fish
@@ -1,18 +1,14 @@
 function fzf_tmux_files_popup
-    # PARENT_PANE / PARENT_PID are injected by the tmux.conf popup command
-    set -l parent_pane "$PARENT_PANE"
-    set -l parent_pid "$PARENT_PID"
-    if test -z "$parent_pane"
-        set parent_pane (tmux display-message -p '#{pane_id}')
-    end
-    if test -z "$parent_pid"
-        set parent_pid (tmux display-message -p '#{pane_pid}')
-    end
+    # parent pane ID stored in tmux buffer by the key binding before popup opens
+    set -l parent_pane (tmux show-buffer -b _fzf_parent_pane 2>/dev/null | string trim)
 
     # Detect if parent pane is running an AI coding tool → prefix paths with '@'
     set -l at_prefix_mode false
-    if pgrep -P "$parent_pid" -f 'claude|gemini|codex|copilot' > /dev/null 2>&1
-        set at_prefix_mode true
+    if test -n "$parent_pane"
+        set -l pane_cmd (tmux display-message -t "$parent_pane" -p '#{pane_current_command}' 2>/dev/null)
+        if string match -qr 'claude|gemini|codex|copilot' -- "$pane_cmd"
+            set at_prefix_mode true
+        end
     end
 
     set -l selected (
@@ -21,11 +17,11 @@ function fzf_tmux_files_popup
             --height=100% \
             --prompt="Files> " \
             --preview '
-                if [ -d {} ]; then
+                if [ -d {} ]
                     eza --all --icons --color=always --tree --level=2 --git-ignore {}
                 else
                     bat --color=always --style=numbers --line-range :300 {}
-                fi
+                end
             ' \
             --preview-window=down:60%:wrap
     )
@@ -45,5 +41,5 @@ function fzf_tmux_files_popup
         end
     end
 
-    tmux send-keys -t "$parent_pane" -l -- "$output"
+    tmux send-keys -l -- "$output"
 end

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -37,7 +37,7 @@ bind -n C-S-. next-window
 bind -n C-S-w display-popup -E "fish -c 'fzf_tmux_windows_popup'"
 
 # files
-bind C-f display-popup -d "#{pane_current_path}" -E -w 80% -h 80% "PARENT_PANE=#{pane_id} PARENT_PID=#{pane_pid} fish -c 'fzf_tmux_files_popup'"
+bind C-f run-shell "tmux set-buffer -b _fzf_parent_pane '#{pane_id}'" \; display-popup -d "#{pane_current_path}" -E -w 80% -h 80% "fish -c 'fzf_tmux_files_popup'"
 bind C-g display-popup -d "#{pane_current_path}" -w 95% -h 90% "lazygit"
 
 # Swap pane


### PR DESCRIPTION
Fix issues with file selection popup (`<prefix>C-f`) not sending selected results to the calling pane and missing `@` prefix detection for AI tools

## Changes

**Fix file path transmission failure**

Removed explicit target from `send-keys -t "$parent_pane"` and reverted to tmux popup's default behavior (sending to the pane that spawned the popup)

**Fix missing `@` prefix (two root causes addressed)**

1. `#{pane_id}` inside `display-popup` command arguments was not being expanded, resulting in the literal string `#pane_id}`. Changed to save via `tmux set-buffer -b _fzf_parent_pane '#{pane_id}'` in `run-shell` first, then read with `show-buffer` inside the popup
2. `pgrep -P` for child process lookup was unstable on macOS. Changed to direct detection via `tmux display-message -t "$parent_pane" -p '#{pane_current_command}'`

**Fix preview syntax error**

fzf executes preview commands using `$SHELL` (fish), so reverted sh syntax `then/fi` to fish syntax `end`