### PR TITLE
fix: Renovate が BEHIND になった PR を rebase できるようにする

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,7 @@
   enabledManagers: ["mise", "github-actions", "custom.regex"],
   automergeType: "pr",
   platformAutomerge: true,
+  rebaseWhen: "behind-base-branch",
   ignoreTests: false,
   customManagers: [
     {


### PR DESCRIPTION
## 概要
Renovate の auto-merge 対象 PR が branch protection の strict status checks により `BEHIND` のまま残っていたため、base 更新時に PR を rebase できるよう `rebaseWhen: "behind-base-branch"` を追加

## 変更内容
- `renovate.json5` に `rebaseWhen: "behind-base-branch"` を追加

## 補足
- `Require branches to be up to date before merging` は維持
- `platformAutomerge: true` + `automergeType: "pr"` のまま、stale PR の追従だけ Renovate に任せる構成
