### PR TITLE
fix: Renovate 実行バージョンを 43.214.4 に上げる

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -9,7 +9,7 @@ permissions:
 
 env:
   # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
-  RENOVATE_VERSION: 43.181.2
+  RENOVATE_VERSION: 43.214.4
 
 jobs:
   dependency-validation:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,5 +31,5 @@ jobs:
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
-          renovate-version: 43.182.1
+          renovate-version: 43.214.4
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## 概要
Renovate の auto-merge 対象 PR が `BEHIND` のまま rebase されない状況を切り分けるため、workflow が使う Renovate 実行バージョンを `43.214.4` へ更新

## 変更内容
- `.github/workflows/renovate.yml` の `renovate-version` を `43.214.4` に更新
- `.github/workflows/dependency-validation.yml` の `RENOVATE_VERSION` を `43.214.4` に更新

## 補足
- 既存の branch protection は変更しない
- `rebaseWhen: "behind-base-branch"` を入れても既存 PR が rebase されなかったため、Renovate 本体の挙動差を先に確認する
