### PR TITLE
refactor: simplify Hammerspoon init.lua and add function comments

### DIFF
--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -20,10 +20,22 @@ local arrowByKeyCode = {
   [keycodes.map.l] = "right",
 }
 
+-- Groups of physical-modifier masks, ordered for building modifier lists and
+-- checking whether any non-command modifier is active.
+local modifierGroups = {
+  { "shift", { rawFlagMasks.shift, rawFlagMasks.deviceLeftShift, rawFlagMasks.deviceRightShift } },
+  { "alt",   { rawFlagMasks.alternate, rawFlagMasks.deviceLeftAlternate, rawFlagMasks.deviceRightAlternate } },
+  { "ctrl",  { rawFlagMasks.control, rawFlagMasks.deviceLeftControl, rawFlagMasks.deviceRightControl } },
+  { "fn",    { rawFlagMasks.secondaryFn } },
+}
+
+-- Returns true if the given raw flag bitmask has the specified flag bit set.
 local function hasFlag(rawFlags, mask)
   return mask ~= nil and (rawFlags & mask) ~= 0
 end
 
+-- Appends modifier to the list if any of the given masks is set in rawFlags.
+-- Stops at the first match so the modifier is never added twice.
 local function appendModifier(modifiers, rawFlags, modifier, masks)
   for _, mask in ipairs(masks) do
     if hasFlag(rawFlags, mask) then
@@ -33,19 +45,28 @@ local function appendModifier(modifiers, rawFlags, modifier, masks)
   end
 end
 
+-- Returns true if any non-Command modifier key (shift, alt, ctrl, fn) is active.
+-- Used to decide whether a lone Command tap should send its replacement key.
 local function hasAnyModifierExceptCommand(rawFlags)
-  return hasFlag(rawFlags, rawFlagMasks.shift)
-    or hasFlag(rawFlags, rawFlagMasks.deviceLeftShift)
-    or hasFlag(rawFlags, rawFlagMasks.deviceRightShift)
-    or hasFlag(rawFlags, rawFlagMasks.alternate)
-    or hasFlag(rawFlags, rawFlagMasks.deviceLeftAlternate)
-    or hasFlag(rawFlags, rawFlagMasks.deviceRightAlternate)
-    or hasFlag(rawFlags, rawFlagMasks.control)
-    or hasFlag(rawFlags, rawFlagMasks.deviceLeftControl)
-    or hasFlag(rawFlags, rawFlagMasks.deviceRightControl)
-    or hasFlag(rawFlags, rawFlagMasks.secondaryFn)
+  for _, group in ipairs(modifierGroups) do
+    for _, mask in ipairs(group[2]) do
+      if hasFlag(rawFlags, mask) then return true end
+    end
+  end
+  return false
 end
 
+-- Returns true if the physical left Command key is currently held.
+-- Falls back to the generic Command flag when the device-specific bit is absent,
+-- excluding right Command to avoid false positives.
+local function isLeftCommandDown(rawFlags)
+  return hasFlag(rawFlags, rawFlagMasks.deviceLeftCommand)
+    or (hasFlag(rawFlags, rawFlagMasks.command) and not hasFlag(rawFlags, rawFlagMasks.deviceRightCommand))
+end
+
+-- Posts a key-down + key-up pair for the given key code.
+-- doAfter(0) defers posting until after the current event-tap callback returns,
+-- avoiding re-entrancy issues with the flagsChanged handler.
 local function sendKeyStroke(keyCodeToSend)
   timer.doAfter(0, function()
     event.newKeyEvent({}, keyCodeToSend, true):post()
@@ -64,6 +85,8 @@ local commandState = {
   },
 }
 
+-- Updates the tracked state for one Command key (left or right) and sends the
+-- replacement key when the key is released without having been used as a modifier.
 local function handleCommandChange(side, isDown, replacementKeyCode, rawFlags)
   local state = commandState[side]
 
@@ -86,6 +109,8 @@ local function handleCommandChange(side, isDown, replacementKeyCode, rawFlags)
   end
 end
 
+-- Marks any currently-held Command key as "used" so its solo-tap replacement
+-- is suppressed. Called whenever a non-Command key is pressed.
 local function markPressedCommandsAsUsed()
   if commandState.left.isDown then
     commandState.left.wasUsed = true
@@ -96,13 +121,15 @@ local function markPressedCommandsAsUsed()
   end
 end
 
+-- Handles flagsChanged events to track Command key press/release.
+-- When both Command keys are held simultaneously, both are marked as used
+-- so neither solo-tap replacement fires.
 local function handleFlagsChanged(eventObject)
   local changedKeyCode = eventObject:getKeyCode()
   local rawFlags = eventObject:rawFlags()
 
   if changedKeyCode == keyCode.leftCommand then
-    local isDown = hasFlag(rawFlags, rawFlagMasks.deviceLeftCommand)
-      or (hasFlag(rawFlags, rawFlagMasks.command) and not hasFlag(rawFlags, rawFlagMasks.deviceRightCommand))
+    local isDown = isLeftCommandDown(rawFlags)
 
     if isDown and commandState.right.isDown then
       commandState.right.wasUsed = true
@@ -140,41 +167,21 @@ local function modifiersWithoutRightCommand(rawFlags)
   -- Right Command is the layer trigger; keep the other physical modifiers.
   local modifiers = {}
 
-  appendModifier(modifiers, rawFlags, "shift", {
-    rawFlagMasks.shift,
-    rawFlagMasks.deviceLeftShift,
-    rawFlagMasks.deviceRightShift,
-  })
-
-  appendModifier(modifiers, rawFlags, "alt", {
-    rawFlagMasks.alternate,
-    rawFlagMasks.deviceLeftAlternate,
-    rawFlagMasks.deviceRightAlternate,
-  })
-
-  appendModifier(modifiers, rawFlags, "ctrl", {
-    rawFlagMasks.control,
-    rawFlagMasks.deviceLeftControl,
-    rawFlagMasks.deviceRightControl,
-  })
-
-  if hasFlag(rawFlags, rawFlagMasks.deviceLeftCommand)
-    or (hasFlag(rawFlags, rawFlagMasks.command) and not hasFlag(rawFlags, rawFlagMasks.deviceRightCommand)) then
-    table.insert(modifiers, "cmd")
+  for _, group in ipairs(modifierGroups) do
+    appendModifier(modifiers, rawFlags, group[1], group[2])
   end
 
-  appendModifier(modifiers, rawFlags, "fn", {
-    rawFlagMasks.secondaryFn,
-  })
+  if isLeftCommandDown(rawFlags) then
+    table.insert(modifiers, "cmd")
+  end
 
   return modifiers
 end
 
+-- Remaps right Command + h/j/k/l to arrow keys, preserving any other active
+-- modifiers (e.g. shift for selection, cmd for word-level movement).
+-- Returns false to pass the event through unchanged if the conditions are not met.
 local function remapRightCommandHjkl(eventObject)
-  if eventObject:getType() == eventTypes.keyDown then
-    markPressedCommandsAsUsed()
-  end
-
   local arrowKey = arrowByKeyCode[eventObject:getKeyCode()]
   if arrowKey == nil then
     return false
@@ -191,10 +198,18 @@ local function remapRightCommandHjkl(eventObject)
   return true, { mappedEvent }
 end
 
+-- Top-level event-tap callback. Routes flagsChanged events to the Command-key
+-- tracker and all other events to the hjkl remapper.
 local function handleKeyboardEvent(eventObject)
-  if eventObject:getType() == eventTypes.flagsChanged then
+  local eventType = eventObject:getType()
+
+  if eventType == eventTypes.flagsChanged then
     handleFlagsChanged(eventObject)
     return false
+  end
+
+  if eventType == eventTypes.keyDown then
+    markPressedCommandsAsUsed()
   end
 
   return remapRightCommandHjkl(eventObject)

--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -180,8 +180,9 @@ end
 
 -- Remaps right Command + h/j/k/l to arrow keys, preserving any other active
 -- modifiers (e.g. shift for selection, cmd for word-level movement).
+-- isKeyDown is passed in from the caller to avoid a redundant getType() call.
 -- Returns false to pass the event through unchanged if the conditions are not met.
-local function remapRightCommandHjkl(eventObject)
+local function remapRightCommandHjkl(eventObject, isKeyDown)
   local arrowKey = arrowByKeyCode[eventObject:getKeyCode()]
   if arrowKey == nil then
     return false
@@ -192,7 +193,6 @@ local function remapRightCommandHjkl(eventObject)
     return false
   end
 
-  local isKeyDown = eventObject:getType() == eventTypes.keyDown
   local mappedEvent = event.newKeyEvent(modifiersWithoutRightCommand(rawFlags), arrowKey, isKeyDown)
 
   return true, { mappedEvent }
@@ -212,7 +212,7 @@ local function handleKeyboardEvent(eventObject)
     markPressedCommandsAsUsed()
   end
 
-  return remapRightCommandHjkl(eventObject)
+  return remapRightCommandHjkl(eventObject, eventType == eventTypes.keyDown)
 end
 
 -- Keep a global reference so Hammerspoon does not garbage collect the event tap.


### PR DESCRIPTION
## Summary
Refactor `.hammerspoon/init.lua` following a `/simplify` review — no behavior changes.

## Changes
- Extract `isLeftCommandDown(rawFlags)` helper to eliminate duplicated three-line flag logic shared between `handleFlagsChanged` and `modifiersWithoutRightCommand`
- Centralize physical modifier masks in a `modifierGroups` table; both `hasAnyModifierExceptCommand` and `modifiersWithoutRightCommand` now iterate it, so adding a modifier requires a single edit
- Move `markPressedCommandsAsUsed()` call from `remapRightCommandHjkl` to `handleKeyboardEvent` so the remap function is free of command-state side effects
- Cache `eventObject:getType()` in `handleKeyboardEvent` to avoid a redundant FFI call on every key event
- Add English doc-comments to all functions explaining intent and non-obvious invariants (e.g. why `sendKeyStroke` defers via `doAfter(0)`, why the pre/post `wasUsed` marks in `handleFlagsChanged` are both necessary)

## Notes
- Relates to #55 (original Hammerspoon feature)