### PR TITLE
chore: update Ghostty fallback font from UDEV Gothic NFLG to Juisee

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -7,7 +7,7 @@
 theme = light:Flexoki Light,dark:Kanagawa Dragon
 
 font-family = Berkeley Mono
-font-family = UDEV Gothic NFLG
+font-family = Juisee
 font-size = 15
 
 background-opacity = 0.95


### PR DESCRIPTION
.config/ghostty/config のフォールバックフォント設定を UDEV Gothic NFLG から Juisee に変更。