### PR TITLE
feat(tmux): C-e で yazi ファイルピッカーを開き選択パスを元 pane に入力

### DIFF
--- a/.config/fish/.gitignore
+++ b/.config/fish/.gitignore
@@ -19,6 +19,7 @@ functions/*
 !functions/fzf_tmux_windows.fish
 !functions/fzf_tmux_windows_popup.fish
 !functions/fzf_tmux_files_popup.fish
+!functions/yazi_tmux_files_picker.fish
 !functions/fzf_z_search.fish
 !functions/git.fish
 !functions/git_audit.fish

--- a/.config/fish/functions/yazi_tmux_files_picker.fish
+++ b/.config/fish/functions/yazi_tmux_files_picker.fish
@@ -1,0 +1,53 @@
+function yazi_tmux_files_picker
+    # parent pane ID stored in tmux buffer by the key binding before this window opens
+    set -l parent_pane (tmux show-buffer -b _yazi_parent_pane 2>/dev/null | string trim)
+
+    # Detect if parent pane is running an AI coding tool → prefix paths with '@'
+    set -l at_prefix_mode false
+    if test -n "$parent_pane"
+        set -l pane_cmd (tmux display-message -t "$parent_pane" -p '#{pane_current_command}' 2>/dev/null)
+        if string match -qr 'claude|gemini|codex|copilot' -- "$pane_cmd"
+            set at_prefix_mode true
+        end
+    end
+
+    # Use a /tmp template (not `mktemp -t`) so a stale $TMPDIR inherited by a
+    # long-lived tmux server cannot break chooser mode and fall back to nvim.
+    set -l chooser_file (mktemp /tmp/yazi-chooser.XXXXXX)
+    if test -z "$chooser_file"
+        return 1
+    end
+
+    command yazi --chooser-file="$chooser_file"
+
+    set -l selected (string split -- \n (string trim (cat "$chooser_file")) | string match -vr '^$')
+    rm -f "$chooser_file"
+
+    if not set -q selected[1]
+        # nothing chosen → just restore focus to the original window/pane
+        if test -n "$parent_pane"
+            tmux select-window -t "$parent_pane" 2>/dev/null
+            tmux select-pane -t "$parent_pane" 2>/dev/null
+        end
+        return 0
+    end
+
+    set -l output ""
+    if test "$at_prefix_mode" = true
+        for path in $selected
+            set output "$output@$path "
+        end
+    else
+        for path in $selected
+            set output "$output"(string escape -- $path)" "
+        end
+    end
+
+    if test -n "$parent_pane"
+        tmux send-keys -t "$parent_pane" -l -- "$output"
+        tmux select-window -t "$parent_pane" 2>/dev/null
+        tmux select-pane -t "$parent_pane" 2>/dev/null
+    else
+        tmux send-keys -l -- "$output"
+    end
+end

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -5,6 +5,10 @@ set -g prefix C-z
 set -g default-terminal "$TERM"
 set -ga terminal-overrides ",$TERM:Tc"
 
+set -g allow-passthrough all
+set -ga update-environment TERM
+set -ga update-environment TERM_PROGRAM
+
 # View
 set -g history-limit 10000
 set -g base-index 1
@@ -39,6 +43,7 @@ bind -n C-S-w display-popup -E "fish -c 'fzf_tmux_windows_popup'"
 # files
 bind C-f run-shell "tmux set-buffer -b _fzf_parent_pane '#{pane_id}'" \; display-popup -d "#{pane_current_path}" -E -w 80% -h 80% "fish -c 'fzf_tmux_files_popup'"
 bind C-g display-popup -d "#{pane_current_path}" -w 95% -h 90% "lazygit"
+bind C-e run-shell "tmux set-buffer -b _yazi_parent_pane '#{pane_id}'" \; new-window -a -t '{end}' -n yazi -c "#{pane_current_path}" "fish -c 'yazi_tmux_files_picker'"
 
 # Swap pane
 bind N swap-pane -D

--- a/.config/yazi/package.toml
+++ b/.config/yazi/package.toml
@@ -1,0 +1,12 @@
+[plugin]
+deps = []
+
+[[flavor.deps]]
+use = "marcosvnmelo/kanagawa-dragon"
+rev = "b433f4a"
+hash = "b967c24a30350b1c5cd3a2ad5a7732e7"
+
+[[flavor.deps]]
+use = "gosxrgxx/flexoki-light"
+rev = "1b1e677"
+hash = "a80630a255909a511aba8a98d115bc15"

--- a/.config/yazi/theme.toml
+++ b/.config/yazi/theme.toml
@@ -1,0 +1,5 @@
+#:schema https://yazi-rs.github.io/schemas/theme.json
+
+[flavor]
+dark = "kanagawa-dragon"
+light = "flexoki-light"

--- a/.config/yazi/yazi.toml
+++ b/.config/yazi/yazi.toml
@@ -1,0 +1,8 @@
+# A TOML linter such as https://taplo.tamasfe.dev/ can use this schema to validate your config.
+# If you encounter any issues, please make an issue at https://github.com/yazi-rs/schemas.
+
+#:schema https://yazi-rs.github.io/schemas/yazi.json
+
+[mgr]
+show_hidden    = true
+show_symlink   = true


### PR DESCRIPTION
## 概要
`C-z C-e`（tmux prefix + `C-e`）で yazi を開き、選択したファイル/ディレクトリの
パスを、起動元の pane に入力できるようにする。あわせて yazi の基本設定も追加。
既存の `fzf_tmux_files_popup` パターンを踏襲した実装。

旧 `C-e`（`y` ラッパーで cd）はこの機能に置き換え。

## 変更点
### tmux ファイルピッカー
- `yazi_tmux_files_picker`（fish 関数）を新規追加
  - `yazi --chooser-file` で選択結果を取得
  - 選択パスを整形（`string escape`。親 pane が AI CLI の場合は `@` プレフィックス）
  - `send-keys -t` で元 pane に入力し、フォーカスを元のウィンドウ/pane に復帰
- `C-e` を、末尾（`{end}`）に追加した専用ウィンドウで picker を開くようにバインド
- `.config/fish/.gitignore` に関数の whitelist を追加

### yazi 基本設定
- `yazi.toml`: manager で `show_hidden` / `show_symlink` を有効化
- `theme.toml`: flavor を kanagawa-dragon（dark）/ flexoki-light（light）に設定
- `package.toml`: flavor パッケージの依存を固定（`flavors/` は gitignore のまま、
  `ya pkg` で再インストール）

## 実装中に解決した不具合
1. **popup 即クラッシュ（TRT）**: tmux の `display-popup` は passthrough 非対応のため、
   yazi の端末問い合わせ応答が返らずクラッシュ。→ 一時ウィンドウ方式に変更。
2. **既存ウィンドウの番号が変わる**: `renumber-windows on` + カレント隣挿入が原因。
   → `new-window -a -t '{end}'` で末尾固定挿入にして番号を保持。
3. **選択後フォーカスが戻らない**: `select-window` / `select-pane` で復帰。
4. **Enter で nvim が開く**: 長寿命 tmux サーバが保持する古い `$TMPDIR` で
   `mktemp -t` が失敗し空パス → chooser モードが無効化され通常 opener が起動。
   → `/tmp` 固定テンプレートに変更して解消。

## 検証
- `fish -n .config/fish/functions/yazi_tmux_files_picker.fish` 構文 OK
- tmux config パースエラーなし
- 末尾ウィンドウ挿入で既存ウィンドウ番号が不変であることを headless tmux で確認
- `C-z C-e` → ファイル/ディレクトリ選択 → 元 pane へパス入力 / フォーカス復帰を確認


## flavors のインストール
`flavors/` は gitignore 対象（yazi のパッケージマネージャ管理）。`package.toml` に
固定した flavor を取得・反映するには次を実行する。

```fish
ya pkg install
```

新環境では `./setup.sh` 実行後にこのコマンドでテーマが揃う。
