### PR TITLE
fix(renovate): enable platform commits for app

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
   enabledManagers: ["mise", "github-actions"],
   automergeType: "pr",
   platformAutomerge: true,
+  platformCommit: "enabled",
   rebaseWhen: "behind-base-branch",
   ignoreTests: false,
   labels: ["dependencies"],


### PR DESCRIPTION
Renovate App が GitHub platform commit を使うよう `platformCommit: "enabled"` を追加
