### PR TITLE
chore: add herdr fish functions

### DIFF
--- a/.config/fish/.gitignore
+++ b/.config/fish/.gitignore
@@ -10,6 +10,9 @@ functions/*
 !functions/__dotfiles_apply_theme_mode.fish
 !functions/__dotfiles_repair_nvim_lazy_checkouts.fish
 !functions/__dotfiles_theme_mode.fish
+!functions/__herdr_cd_active_pane_cwd.fish
+!functions/__herdr_send_paths_to_pane.fish
+!functions/__herdr_target_pane_id.fish
 !functions/fish_greeting.fish
 !functions/fish_title.fish.bak
 !functions/fish_user_key_bindings.fish
@@ -24,6 +27,10 @@ functions/*
 !functions/fzf_z_search.fish
 !functions/git.fish
 !functions/git_audit.fish
+!functions/herdr_files_picker.fish
+!functions/herdr_lazygit.fish
+!functions/herdr_tabs_picker.fish
+!functions/herdr_yazi_files_picker.fish
 !functions/push_line.fish
 !functions/theme_sync.fish
 !functions/update_tools.fish

--- a/.config/fish/functions/__herdr_cd_active_pane_cwd.fish
+++ b/.config/fish/functions/__herdr_cd_active_pane_cwd.fish
@@ -1,0 +1,5 @@
+function __herdr_cd_active_pane_cwd
+    if set -q HERDR_ACTIVE_PANE_CWD; and test -d "$HERDR_ACTIVE_PANE_CWD"
+        cd "$HERDR_ACTIVE_PANE_CWD"
+    end
+end

--- a/.config/fish/functions/__herdr_send_paths_to_pane.fish
+++ b/.config/fish/functions/__herdr_send_paths_to_pane.fish
@@ -1,0 +1,34 @@
+function __herdr_send_paths_to_pane
+    set -l target_pane $argv[1]
+    set -l paths $argv[2..-1]
+
+    if test -z "$target_pane"; or not set -q paths[1]
+        return 1
+    end
+
+    command -sq jq; or return 1
+
+    set -l pane_agent (herdr pane get "$target_pane" 2>/dev/null | jq -r '.result.pane.agent // ""')
+    set -l pane_processes (
+        herdr pane process-info --pane "$target_pane" 2>/dev/null |
+            jq -r '[.result.process_info.foreground_processes[]? | .name, .argv0, .cmdline] | join(" ")'
+    )
+
+    set -l use_agent_paths false
+    if string match -qir 'claude|gemini|codex|copilot' -- "$pane_agent $pane_processes"
+        set use_agent_paths true
+    end
+
+    set -l output ""
+    if test "$use_agent_paths" = true
+        for path in $paths
+            set output "$output@$path "
+        end
+    else
+        for path in $paths
+            set output "$output"(string escape -- $path)" "
+        end
+    end
+
+    herdr pane send-text "$target_pane" "$output" >/dev/null
+end

--- a/.config/fish/functions/__herdr_target_pane_id.fish
+++ b/.config/fish/functions/__herdr_target_pane_id.fish
@@ -1,0 +1,10 @@
+function __herdr_target_pane_id
+    if set -q HERDR_ACTIVE_PANE_ID; and test -n "$HERDR_ACTIVE_PANE_ID"
+        echo "$HERDR_ACTIVE_PANE_ID"
+        return 0
+    end
+
+    command -sq jq; or return 1
+
+    herdr pane current --current 2>/dev/null | jq -r '.result.pane.pane_id // empty'
+end

--- a/.config/fish/functions/herdr_files_picker.fish
+++ b/.config/fish/functions/herdr_files_picker.fish
@@ -1,0 +1,29 @@
+function herdr_files_picker
+    __herdr_cd_active_pane_cwd
+
+    set -l target_pane (__herdr_target_pane_id)
+    if test -z "$target_pane"
+        return 1
+    end
+
+    set -l selected (
+        fd --hidden --follow --type f --type d --exclude .git --exclude .DS_Store --strip-cwd-prefix |
+            fzf --exit-0 --multi \
+                --height=100% \
+                --prompt="Files> " \
+                --preview '
+                    if [ -d {} ]
+                        eza --all --icons --color=always --tree --level=2 --git-ignore {}
+                    else
+                        bat --color=always --style=numbers --line-range :300 {}
+                    end
+                ' \
+                --preview-window=down:60%:wrap
+    )
+
+    if not set -q selected[1]
+        return 0
+    end
+
+    __herdr_send_paths_to_pane "$target_pane" $selected
+end

--- a/.config/fish/functions/herdr_lazygit.fish
+++ b/.config/fish/functions/herdr_lazygit.fish
@@ -1,0 +1,4 @@
+function herdr_lazygit
+    __herdr_cd_active_pane_cwd
+    command lazygit
+end

--- a/.config/fish/functions/herdr_tabs_picker.fish
+++ b/.config/fish/functions/herdr_tabs_picker.fish
@@ -1,0 +1,25 @@
+function herdr_tabs_picker
+    command -sq jq; or return 1
+
+    set -l workspace_arg
+    if set -q HERDR_ACTIVE_WORKSPACE_ID; and test -n "$HERDR_ACTIVE_WORKSPACE_ID"
+        set workspace_arg --workspace "$HERDR_ACTIVE_WORKSPACE_ID"
+    end
+
+    set -l selected (
+        herdr tab list $workspace_arg |
+            jq -r '.result.tabs[] | [.tab_id, ((.number | tostring) + ": " + (.label // "")), ((.pane_count | tostring) + " panes"), (.agent_status // "unknown"), (if .focused then "*" else "" end)] | @tsv' |
+            fzf --exit-0 --no-multi --prompt="herdr tabs> " --height=~50% --border
+    )
+
+    if test -z "$selected"
+        return 0
+    end
+
+    set -l fields (string split \t -- "$selected")
+    if test -z "$fields[1]"
+        return 1
+    end
+
+    herdr tab focus "$fields[1]" >/dev/null
+end

--- a/.config/fish/functions/herdr_yazi_files_picker.fish
+++ b/.config/fish/functions/herdr_yazi_files_picker.fish
@@ -1,0 +1,24 @@
+function herdr_yazi_files_picker
+    __herdr_cd_active_pane_cwd
+
+    set -l target_pane (__herdr_target_pane_id)
+    if test -z "$target_pane"
+        return 1
+    end
+
+    set -l chooser_file (mktemp /tmp/yazi-herdr-chooser.XXXXXX)
+    if test -z "$chooser_file"
+        return 1
+    end
+
+    command yazi --chooser-file="$chooser_file"
+
+    set -l selected (string split -- \n (string trim (cat "$chooser_file")) | string match -vr '^$')
+    rm -f "$chooser_file"
+
+    if not set -q selected[1]
+        return 0
+    end
+
+    __herdr_send_paths_to_pane "$target_pane" $selected
+end


### PR DESCRIPTION
## 概要

`herdr` の設定ファイルから呼び出している fish 関数を dotfiles に取り込みました

追加した関数は `herdr_tabs_picker`, `herdr_files_picker`, `herdr_lazygit`, `herdr_yazi_files_picker` と、それらが利用する `__herdr_*` helper です

`.config/fish/.gitignore` の allowlist も更新し、repo 管理対象として扱われるようにしています
